### PR TITLE
Fixed type in fillbposcommon

### DIFF
--- a/ref/sample.kloe
+++ b/ref/sample.kloe
@@ -62,7 +62,7 @@ C
 C Put A_C Error Code to SUCCESS at Run_Init
 C
       Status = ANPIST(ANSUCC)
-      istat = fibposcommon(nrun)
+      istat = fillbposcommon(nrun)
 C
       RETURN
       END


### PR DESCRIPTION
SAMRI had a typo I introduced after testing. 
Fix and compiles now