### PR TITLE
Fixed abortion problem in fibm11 related to TreeWriter destructor

### DIFF
--- a/ref/Fort2C.cpp
+++ b/ref/Fort2C.cpp
@@ -21,7 +21,6 @@ void inittree_(){
 // input:   -
 // output:  -
 void fillntu_(){
-  std::cout << evtinfo_.PhiD << std::endl;
   writer->fillTTree();
 }
 
@@ -31,6 +30,7 @@ void fillntu_(){
 // output:  -
 void closetree_(){
   delete writer;
+  writer = NULL;
 }
 
 #endif

--- a/ref/TreeWriter.cpp
+++ b/ref/TreeWriter.cpp
@@ -36,14 +36,16 @@ TreeWriter::TreeWriter() {
 // input:   -
 // return:  -
 TreeWriter::~TreeWriter() {
-    /* std::cout << "Destructor " << std::endl; */
+    if(fNewTree){
+      delete fNewTree;
+      fNewTree = NULL;
+    }
+
     if(outfile) {
         outfile->Write(0,TObject::kOverwrite);
         outfile->Close();
         delete outfile;
-    }
-    if(fNewTree){
-        delete fNewTree;
+	outfile = NULL;
     }
 }
 


### PR DESCRIPTION
fNewTree needs to be erased before outfile since it belongs to the same workspace
if not causes abortion in fibm11 (???)
Added setting to NULL after erasing
Removed some comments